### PR TITLE
Fairly major changes; add --update

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,4 +54,3 @@ This project is developed and maintained by [http://buildkite.com](Buildkite)
 ### Copyright
 
 Copyright (c) 2015 Keith Pitt, Tim Lucas, Buildkite Pty Ltd. See LICENSE for details.
-Copyright (c) 2018 David Parsley

--- a/Readme.md
+++ b/Readme.md
@@ -5,11 +5,14 @@
 ### Usage
 
 ```bash
-$ github-release "v1.0" pkg/*.tar.gz --commit "branch-or-sha" \
-                                     --tag "1-0-0-stable" \
-                                     --prerelease \
-                                     --github-repository "your/repo" \
-                                     --github-access-token [..]
+$ github-release <release name> <fileglob> \
+    --target <target> \ # defaults to master, for release commitish
+    --commit <sha> \ # commit hash for tag ref
+    --tag <tag> \ # defaults to the name of the release
+    --prerelease \ # defaults to false
+    --update \ # update if release exists, defaults to false
+    --github-repository <userorg/repo> \
+    --github-access-token <token>
 ```
 
 Environment variables can also be used:
@@ -18,8 +21,10 @@ Environment variables can also be used:
 $ export GITHUB_RELEASE_ACCESS_TOKEN="..."
 $ export GITHUB_RELEASE_REPOSITORY="..."
 $ export GITHUB_RELEASE_TAG="..."
+$ export GITHUB_RELEASE_TARGET="..."
 $ export GITHUB_RELEASE_COMMIT="..."
 $ export GITHUB_RELEASE_PRERELEASE="..."
+$ export GITHUB_RELEASE_UPDATE="..."
 $ github-release "v1.0" pkg/*.tar.gz
 ```
 
@@ -49,3 +54,4 @@ This project is developed and maintained by [http://buildkite.com](Buildkite)
 ### Copyright
 
 Copyright (c) 2015 Keith Pitt, Tim Lucas, Buildkite Pty Ltd. See LICENSE for details.
+Copyright (c) 2018 David Parsley


### PR DESCRIPTION
I just want to lead out and say I'm not expecting this to be merged (certainly not as-is), but I wanted to give buildkite a look at my changes, and offer to create a cleaner PR if the changes are desired.

My goal was a github-release tool that allowed smooth updates to snapshot pre-releases. As I push changes to feature branches, it's helpful to have automatic build and publish to a pre-release on github, but none of the existing github release publishing tools appeared to offer that ability. Of the tools I examined, your github-release seemed most amenable to modification.

While my patched version suits my needs, it puts more requirements on potential users, as the commit hash is now required. The big upshot for me is that when e.g. a new 1.0.1-snapshot build completes, github correctly reports the snapshot release was "5 minutes ago", and not "10 days ago" (when the *first* 1.0.1-snapshot was built).